### PR TITLE
remove promise in signOut action

### DIFF
--- a/src/actions/user/sign-out.js
+++ b/src/actions/user/sign-out.js
@@ -10,10 +10,8 @@ export default (user) => {
   return (dispatch) =>{
     console.log('logging out user...')
     api.signOut(user)
-    .then((result) => {
-      dispatch(signedOutUser(user))
-      history.push('/users/sign-in')
-    })
+    dispatch(signedOutUser(user))
+    history.push('/users/sign-in')
   }
 }
 


### PR DESCRIPTION
A promise is always a promise...except in this case...it broke the redirect to the sign-in component.